### PR TITLE
Remove debug assert and re-export Context & Header64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kdmp-parser"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Axel '0vercl0k' Souchet"]
 categories = ["parser-implementations"]
@@ -9,7 +9,7 @@ include = ["/Cargo.toml", "/LICENSE", "/src/**", "/examples/**", "README.md"]
 keywords = ["windows", "kernel", "crashdump"]
 license = "MIT"
 repository = "https://github.com/0vercl0k/kdmp-parser-rs"
-rust-version = "1.70"
+rust-version = "1.75"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,4 @@ pub use gxa::{Gpa, Gva, Gxa};
 pub use map::{MappedFileReader, Reader};
 pub use parse::KernelDumpParser;
 pub use pxe::{Pfn, Pxe, PxeFlags};
-pub use structs::DumpType;
+pub use structs::{Context, DumpType, Header64};

--- a/src/map.rs
+++ b/src/map.rs
@@ -17,13 +17,13 @@ pub struct MappedFileReader<'map> {
     cursor: io::Cursor<&'map [u8]>,
 }
 
-impl<'map> Debug for MappedFileReader<'map> {
+impl Debug for MappedFileReader<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MappedFileReader").finish()
     }
 }
 
-impl<'map> MappedFileReader<'map> {
+impl MappedFileReader<'_> {
     /// Create a new [`MappedFileReader`] from a path using a memory map.
     pub fn new(path: impl AsRef<Path>) -> io::Result<Self> {
         // Open the file..
@@ -39,13 +39,13 @@ impl<'map> MappedFileReader<'map> {
     }
 }
 
-impl<'map> Read for MappedFileReader<'map> {
+impl Read for MappedFileReader<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.cursor.read(buf)
     }
 }
 
-impl<'map> Seek for MappedFileReader<'map> {
+impl Seek for MappedFileReader<'_> {
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
         self.cursor.seek(pos)
     }
@@ -53,7 +53,7 @@ impl<'map> Seek for MappedFileReader<'map> {
 
 /// Drop the [`MappedFileReader`]. In the case we memory mapped the file, we
 /// need to drop the mapping using OS-provided APIs.
-impl<'map> Drop for MappedFileReader<'map> {
+impl Drop for MappedFileReader<'_> {
     fn drop(&mut self) {
         unmap_memory_mapped_file(self.mapped_file).expect("failed to unmap")
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -95,7 +95,7 @@ where
         let dll_end_addr = data
             .dll_base
             .checked_add(data.size_of_image.into())
-            .ok_or_else(|| KdmpParserError::Overflow("module address"))?;
+            .ok_or(KdmpParserError::Overflow("module address"))?;
         let at = Gva::new(data.dll_base.into())..Gva::new(dll_end_addr.into());
         let inserted = modules.insert(at, dll_name);
         debug_assert!(inserted.is_none());
@@ -129,7 +129,7 @@ fn try_find_prcb(
         // Calculate the address of where the CONTEXT pointer is at..
         let kprcb_context_addr = kprcb_addr
             .checked_add(kd_debugger_data_block.offset_prcb_context.into())
-            .ok_or_else(|| KdmpParserError::Overflow("offset_prcb"))?;
+            .ok_or(KdmpParserError::Overflow("offset_prcb"))?;
 
         // ..and read it.
         let Some(kprcb_context_addr) =
@@ -156,7 +156,7 @@ fn try_find_prcb(
         // Otherwise, let's move on to the next pointer.
         processor_block = processor_block
             .checked_add(mem::size_of::<u64>() as _)
-            .ok_or_else(|| KdmpParserError::Overflow("kprcb ptr"))?;
+            .ok_or(KdmpParserError::Overflow("kprcb ptr"))?;
     }
 
     Ok(None)
@@ -483,7 +483,7 @@ impl KernelDumpParser {
 
         offset
             .checked_add(gpa.offset())
-            .ok_or_else(|| KdmpParserError::Overflow("w/ gpa offset"))
+            .ok_or(KdmpParserError::Overflow("w/ gpa offset"))
     }
 
     /// Read physical memory starting at `gpa` into a `buffer`.
@@ -757,7 +757,7 @@ impl KernelDumpParser {
                 // Calculate the physical address.
                 let phys_addr = run
                     .phys_addr(page_idx)
-                    .ok_or_else(|| KdmpParserError::PhysAddrOverflow(run_idx, page_idx))?;
+                    .ok_or(KdmpParserError::PhysAddrOverflow(run_idx, page_idx))?;
 
                 // We now know where this page lives at, insert it into the physmem map.
                 if physmem.insert(phys_addr, page_offset).is_some() {
@@ -767,7 +767,7 @@ impl KernelDumpParser {
                 // Move the page offset along.
                 page_offset = page_offset
                     .checked_add(Page::size())
-                    .ok_or_else(|| KdmpParserError::PageOffsetOverflow(run_idx, page_idx))?;
+                    .ok_or(KdmpParserError::PageOffsetOverflow(run_idx, page_idx))?;
             }
         }
 
@@ -801,13 +801,13 @@ impl KernelDumpParser {
 
                 // Calculate where the page is.
                 let pa = gpa_from_bitmap(bitmap_idx, bit_idx)
-                    .ok_or_else(|| KdmpParserError::Overflow("pfn in bitmap"))?;
+                    .ok_or(KdmpParserError::Overflow("pfn in bitmap"))?;
 
                 let insert = physmem.insert(pa, page_offset);
                 debug_assert!(insert.is_none());
-                page_offset = page_offset.checked_add(Page::size()).ok_or_else(|| {
-                    KdmpParserError::BitmapPageOffsetOverflow(bitmap_idx, bit_idx)
-                })?;
+                page_offset = page_offset.checked_add(Page::size()).ok_or(
+                    KdmpParserError::BitmapPageOffsetOverflow(bitmap_idx, bit_idx),
+                )?;
             }
         }
 
@@ -889,17 +889,17 @@ impl KernelDumpParser {
 
             for page_idx in 0..pfn_range.number_of_pages {
                 let gpa = gpa_from_pfn_range(&pfn_range, page_idx)
-                    .ok_or_else(|| KdmpParserError::Overflow("w/ pfn_range"))?;
+                    .ok_or(KdmpParserError::Overflow("w/ pfn_range"))?;
                 let insert = physmem.insert(gpa, page_offset);
                 debug_assert!(insert.is_none());
                 page_offset = page_offset
                     .checked_add(Page::size())
-                    .ok_or_else(|| KdmpParserError::Overflow("w/ page_offset"))?;
+                    .ok_or(KdmpParserError::Overflow("w/ page_offset"))?;
             }
 
             page_count = page_count
                 .checked_add(pfn_range.number_of_pages)
-                .ok_or_else(|| KdmpParserError::Overflow("w/ page_count"))?;
+                .ok_or(KdmpParserError::Overflow("w/ page_count"))?;
         }
 
         Ok(physmem)

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -812,10 +812,6 @@ impl KernelDumpParser {
                 let pa = gpa_from_bitmap(bitmap_idx, bit_idx)
                     .ok_or(KdmpParserError::Overflow("pfn in bitmap"))?;
 
-                if last_byte {
-                    println!("pa: {pa:#x?}");
-                }
-
                 let insert = physmem.insert(pa, page_offset);
                 debug_assert!(insert.is_none());
                 page_offset = page_offset.checked_add(Page::size()).ok_or(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -783,7 +783,6 @@ impl KernelDumpParser {
             ));
         }
 
-        debug_assert_eq!(bmp_header.pages % 8, 0);
         let bitmap_size = bmp_header.pages / 8;
         let mut page_offset = bmp_header.first_page;
         let mut physmem = PhysmemMap::new();


### PR DESCRIPTION
The assertion doesn't seem to be necessary. Despite the crashdumps I've tested do assert in debug, they run absolutely fine in release.